### PR TITLE
Add `createAutolink` to GitHub driver

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -349,6 +349,16 @@ export const Repository = {
     const ref = await client().git.createTree(apiArgs);
     return ref.data.sha;
   },
+  createAutolink({ keyPrefix, urlTemplate, alphanumeric }, { self }) {
+    const { name: owner } = self.$argsAt(root.users.one);
+    const { name: repo } = self.$argsAt(root.users.one.repos.one);
+    return client().repos.createAutolink({
+      owner,
+      repo,
+      key_prefix: keyPrefix,
+      url_template: urlTemplate,
+    });
+  },
   commentCreated: {
     async subscribe(_, { self }) {
       const { name: owner } = self.$argsAt(root.users.one);

--- a/memconfig.json
+++ b/memconfig.json
@@ -689,6 +689,25 @@
               }
             ],
             "description": "Creates a new file tree within the repository based on the provided parameters"
+          },
+          {
+            "name": "createAutolink",
+            "type": "Void",
+            "params": [
+              {
+                "name": "keyPrefix",
+                "type": "String"
+              },
+              {
+                "name": "urlTemplate",
+                "type": "String"
+              },
+              {
+                "name": "alphanumeric",
+                "type": "Boolean",
+                "optional": true
+              }
+            ]
           }
         ],
         "events": [

--- a/memconfig.json
+++ b/memconfig.json
@@ -696,16 +696,19 @@
             "params": [
               {
                 "name": "keyPrefix",
-                "type": "String"
+                "type": "String",
+                "description": "The prefix to match issue text against like `T-`"
               },
               {
                 "name": "urlTemplate",
-                "type": "String"
+                "type": "String",
+                "description": "The URL template to use for autolinking issues. Should include `<num>`"
               },
               {
                 "name": "alphanumeric",
                 "type": "Boolean",
-                "optional": true
+                "optional": true,
+                "description": "`true` if link can contain letters, `false` if numbers only"
               }
             ]
           }


### PR DESCRIPTION
Closes T-458

GitHub provides the ability to configure an [autolink](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls) which parses issues/comments for a particular issue pattern and links it back over into an issue tracker (height in our case). 

This only exists at the repo level  and I want to be able to manage it for the whole org via Membrane. 
